### PR TITLE
:memo: #29 README.mdの更新 「主なディレクトリ構成」を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,16 @@
-# React + TypeScript + Vite
+# React Practice App
+React + Vite + TypeScript
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
-```
-
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
-
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+## 主なディレクトリ構成
+```sh
+public/               #... 処理にかけないファイルの収納ディレクトリ
+src/
+  ├── main.tsx        #... エントリーポイント（React実行開始ファイル）
+  ├── App.tsx         #... ルートコンポーネント
+  ├── pages/          #... ページコンポーネントディレクトリ
+  │   ├── Home.tsx    #...... 投稿一覧ページ
+  │   └── post.tsx    #...... 投稿詳細ページ
+  ├── components/     #... コンポーンネントディレクトリ
+  └── assets/         #... 素材置場ディレクトリ
+      └── images/     #....... 画像ファイルディレクトリ
 ```


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #29 

## やったこと
- README.mdに「主なディレクトリ構成」を記述
- ルーティング設定をしたあとでも使いやすいようpagesディレクトリを案として追加
- assetesディレクトリに画像専用のimagesディレクトリを追加

## やらなかったこと
- componentsディレクトリの仕分け（例えばui-elements/とかfeatures/みたいな切り分け）

## 備考
- pagesやimagesディレクトリは次回MTGで不要と判断されれば削除します！