### PR TITLE
mui/joyを利用し、BodyComponentの作成

### DIFF
--- a/src/components/Body.tsx
+++ b/src/components/Body.tsx
@@ -1,0 +1,18 @@
+import Typography from '@mui/joy/Typography';
+import React from 'react';
+
+type BodyProps = {
+  level?: 'body-lg' | 'body-md' | 'body-sm';
+  align?: 'left' | 'center' | 'right' | 'justify';
+  label: string;
+};
+
+const Body: React.FC<BodyProps> = ({ level = 'body-md', align = 'left', label }) => {
+  return (
+    <Typography level={level} textAlign={align}>
+      {label}
+    </Typography>
+  );
+};
+
+export default Body;


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #39 

## やったこと
- mui/joyのTypographyをベースにBodyコンポーネントを作成
**仕様**
```
type BodyProps = {
  level?: 'body-lg' | 'body-md' | 'body-sm';
  align?: 'left' | 'center' | 'right' | 'justify';
  label: string;
};
```
- ３種類の文字サイズを指定可能(lg md sm)
- alignで位置を指定

## やらなかったこと
- 既存コンポーネントへの反映

## 備考

<img width="1252" alt="スクリーンショット 2025-01-03 11 49 53" src="https://github.com/user-attachments/assets/93384a4d-e539-480a-b48e-aca4e340d9fc" />
