### PR TITLE
投稿削除APIを呼び出す処理の実装

### DIFF
--- a/src/api/deletePost.ts
+++ b/src/api/deletePost.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse } from 'axios';
+import { api } from '../lib/api-client.ts';
+
+/**
+ * 投稿削除API実行処理
+ * @param id
+ * @returns
+ */
+const deletePost = async (id: number): Promise<AxiosResponse> => {
+  const response = await api.delete(`/posts/${id}`);
+  return response;
+};
+
+export default deletePost;

--- a/src/features/post/PostDescription.tsx
+++ b/src/features/post/PostDescription.tsx
@@ -5,6 +5,7 @@ import { Box, Button, TextField } from '@mui/material';
 // ---- API ----
 import fetchPostDetail from '../../api/fetchPostDetail';
 import updatePost, { UpdatePostRequest } from '../../api/updatePost';
+import deletePost from '../../api/deletePost';
 
 export default function PostDescription() {
   // 変更前タイトル(保存用変数)
@@ -91,6 +92,23 @@ export default function PostDescription() {
     setIsEdit(true);
   };
 
+  /**
+   * 削除ボタン押下時処理
+   */
+  const onClickDelete = () => {
+    const funcApi = async () => {
+      try {
+        console.log(id);
+        // 投稿削除API実行処理
+        await deletePost(id);
+        // FIXME: 一覧画面に遷移するルーティング処理を実装する
+      } catch {
+        console.error('削除ボタン押下時処理に失敗しました。');
+      }
+    };
+    funcApi();
+  };
+
   return (
     <>
       <h2>投稿の詳細画面</h2>
@@ -105,7 +123,7 @@ export default function PostDescription() {
         // 未編集状態の場合
         <Box>
           <Button onClick={() => onClickEdit()}>編集</Button>
-          <Button>削除</Button>
+          <Button onClick={() => onClickDelete()}>削除</Button>
         </Box>
       )}
       <TextField


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #11 

## やったこと
- フロントで投稿削除API を呼び出す処理を実装

## やらなかったこと
- 画面レイアウトの調整
- 削除処理完了後、一覧画面に遷移するルーティング処理の実装

## 備考
#### 今回手を入れた範囲に関わる仕様(削除機能)
- [x] 投稿IDを用いて投稿削除を行う
- [x] 削除処理
  - 完了 => 一覧画面に遷移する
  - 失敗 => 詳細画面に留まる