### PR TITLE
投稿詳細ページのレイアウト調整

### DIFF
--- a/src/components/button/FormButton.tsx
+++ b/src/components/button/FormButton.tsx
@@ -15,7 +15,12 @@ type Props = {
 
 const FormButton = ({ label, icon = 'send', handleClickButton, ...props }: Props) => {
   return (
-    <Button variant="contained" endIcon={ICON_MAP[icon]} onClick={handleClickButton} {...props}>
+    <Button
+      variant="contained"
+      endIcon={icon ? ICON_MAP[icon] : undefined}
+      onClick={handleClickButton}
+      {...props}
+    >
       {label}
     </Button>
   );

--- a/src/features/post/PostDescription.tsx
+++ b/src/features/post/PostDescription.tsx
@@ -1,12 +1,9 @@
-// ---- React ----
-import { useState } from 'react';
-// ---- MUI ----
-import { Box, Button, TextField } from '@mui/material';
-// ---- API ----
+import React, { useState } from 'react';
+import { Box, Typography, TextField } from '@mui/material';
+import FormButton from '../../components/button/FormButton';
 import updatePost, { UpdatePostRequest } from '../../api/updatePost';
 import deletePost from '../../api/deletePost';
 
-// ---- Types ----
 type Props = {
   id: number;
   title: string;
@@ -94,38 +91,52 @@ export default function PostDescription(props: Props) {
     funcApi();
   };
 
+  const buttons = isEdit
+    ? [
+        { label: 'キャンセル', onClick: onClickCancel },
+        { label: '更新', onClick: onClickUpdate },
+      ]
+    : [
+        { label: '編集', onClick: onClickEdit },
+        { label: '削除', onClick: onClickDelete },
+      ];
+
   return (
     <>
-      <h2>投稿の詳細画面</h2>
-      <p>投稿の内容</p>
-      {isEdit ? (
-        // 編集状態の場合
-        <Box>
-          <Button onClick={() => onClickCancel()}>キャンセル</Button>
-          <Button onClick={() => onClickUpdate()}>更新</Button>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: '100%',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6">ユーザ名</Typography>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          {buttons.map((button, index) => (
+            <FormButton key={index} label={button.label} handleClickButton={button.onClick} />
+          ))}
         </Box>
-      ) : (
-        // 未編集状態の場合
-        <Box>
-          <Button onClick={() => onClickEdit()}>編集</Button>
-          <Button onClick={() => onClickDelete()}>削除</Button>
-        </Box>
-      )}
+      </Box>
       <TextField
         id="title"
         label="タイトル"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         disabled={!isEdit}
+        fullWidth
+        sx={{ mb: 2 }}
       />
       <TextField
         id="body"
         label="本文"
         value={body}
         multiline
-        rows={15}
         onChange={(e) => setBody(e.target.value)}
         disabled={!isEdit}
+        fullWidth
+        sx={{ mb: 2 }}
       />
     </>
   );


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #85 

## やったこと
- 投稿詳細ページのレイアウト調整
- isEditの値による、ボタンコントロール表示のリファクタリング

## やらなかったこと
- HTMLの要素の切り替え(エディットの時にテキストフィールド、それ以外の時はTitleやBodyコンポーネントみたいなことは今回やってない)
  - 別タスクで行う

## 備考

<img width="658" alt="スクリーンショット 2025-01-11 16 12 37" src="https://github.com/user-attachments/assets/6ba24312-5cdd-4504-a734-dde13720b154" />

<img width="622" alt="スクリーンショット 2025-01-11 16 12 46" src="https://github.com/user-attachments/assets/a83de2d2-cec5-4cb3-a114-76ed6269268a" />
