### PR TITLE
投稿一覧・投稿詳細の横幅を調整

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 #root {
+  width: 100%;
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
@@ -39,4 +40,22 @@
 
 .read-the-docs {
   color: #888;
+}
+
+/* ===================
+  投稿一覧
+====================== */
+.home-main-box {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ===================
+  投稿詳細
+====================== */
+.post-main-box {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
 }

--- a/src/features/comment/CommentList.tsx
+++ b/src/features/comment/CommentList.tsx
@@ -1,7 +1,5 @@
 // ---- API ----
 import { Comment } from '../../types/api';
-// ---- MUI ----
-import { Box } from '@mui/material';
 // ---- Component ----
 import Heading from '../../components/typography/Heading';
 import Card from '../../components/card/Card';
@@ -20,10 +18,8 @@ export default function Comments(props: Props) {
       {props.comments?.slice(0, 10).map((comment) => {
         return (
           <Card>
-            <Box sx={{ maxWidth: 800 }}>
-              <Title level="title-md" label={comment.name} />
-              <Body level="body-sm" label={comment.body} />
-            </Box>
+            <Title level="title-md" label={comment.name} />
+            <Body level="body-sm" label={comment.body} />
           </Card>
         );
       })}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+// ---- MUI ----
+import { Box } from '@mui/material';
 // ---- Types ----
 import { Post, User } from '../types/api';
 // ---- API ----
@@ -64,10 +66,12 @@ export default function Home() {
 
   return (
     <>
-      <SectionContainer>
-        <CreatePostForm posts={posts} />
-        <PostFeed posts={posts} />
-      </SectionContainer>
+      <Box className="home-main-box">
+        <SectionContainer>
+          <CreatePostForm posts={posts} />
+          <PostFeed posts={posts} />
+        </SectionContainer>
+      </Box>
     </>
   );
 }

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,5 +1,7 @@
 // ---- React ----
 import { useState, useEffect } from 'react';
+// ---- MUI ----
+import { Box } from '@mui/material';
 // ---- Component ----
 import SectionContainer from '../components/layout/SectionContainer';
 import PostDescription from '../features/post/PostDescription';
@@ -41,7 +43,7 @@ export default function Post() {
   }, [id]);
 
   return (
-    <article>
+    <Box className="post-main-box">
       <SectionContainer>
         <Link
           to={`/`}
@@ -68,6 +70,6 @@ export default function Post() {
       <SectionContainer>
         <CommentList id={id} comments={comments} />
       </SectionContainer>
-    </article>
+    </Box>
   );
 }


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #116 

## やったこと
- App.cssの#rootのwidthに100%を設定
```
#root {
  width: 100%; ← コレ
  max-width: 1280px;
  margin: 0 auto;
  padding: 2rem;
  text-align: center;
}
```
- App.cssに投稿一覧と投稿詳細に要素のメインとなるcssクラスを作成し、以下のcssを適用
```
  width: 100%;
  max-width: 800px;
  margin: 0 auto;
```

## やらなかったこと
- 特になし

## 備考
- 特になし